### PR TITLE
Fix mvn install

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -25,28 +25,8 @@ jobs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-    - name: Deploy gctoolkit-gclogs
-      run: mvn -B deploy --file gctoolkit-gclogs/pom.xml --settings $GITHUB_WORKSPACE/settings.xml
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      
-    - name: Deploy gctoolkit-gclogs-rolling
-      run: mvn -B deploy --file gctoolkit-gclogs-rolling/pom.xml --settings $GITHUB_WORKSPACE/settings.xml
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      
-    - name: Deploy gctoolkit-zgc-logs
-      run: mvn -B deploy --file gctoolkit-zgc-logs/pom.xml --settings $GITHUB_WORKSPACE/settings.xml
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      
-    - name: Deploy gctoolkit-shenandoah-logs
-      run: mvn -B deploy --file gctoolkit-shenandoah-logs/pom.xml --settings $GITHUB_WORKSPACE/settings.xml
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: Deploy top-level pom
+    - name: Deploy gctoolkit-testdata
       run: mvn -B deploy --file pom.xml --settings $GITHUB_WORKSPACE/settings.xml
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        
+      

--- a/gctoolkit-gclogs-rolling/pom.xml
+++ b/gctoolkit-gclogs-rolling/pom.xml
@@ -3,67 +3,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.microsoft.gctoolkit</groupId>
+    <parent>
+        <groupId>com.microsoft.gctoolkit</groupId>
+        <artifactId>gctoolkit-testdata</artifactId>
+        <version>1.0.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>gctoolkit-gclogs-rolling</artifactId>
-    <version>1.0.1</version>
     <packaging>pom</packaging>
-
-    <name>GCToolKit Test Assets: Rolling GC logs</name>
-    <description>Rolling GC logs for testing GCTookKit</description>
-
-
-    <organization>
-        <name>Microsoft Corporation</name>
-        <url>http://microsoft.com</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</connection>
-        <developerConnection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</developerConnection>
-        <url>https://github.com/Microsoft/gctoolkit-testdata</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <id>microsoft</id>
-            <name>Microsoft Corporation</name>
-        </developer>
-    </developers>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/microsoft/gctoolkit-testdata/issues</url>
-    </issueManagement>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
-        </repository>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/gctoolkit-testdata</url>
-        </repository>
-    </distributionManagement>
 
     <build>
         <plugins>

--- a/gctoolkit-gclogs/pom.xml
+++ b/gctoolkit-gclogs/pom.xml
@@ -3,67 +3,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.microsoft.gctoolkit</groupId>
+    <parent>
+        <groupId>com.microsoft.gctoolkit</groupId>
+        <artifactId>gctoolkit-testdata</artifactId>
+        <version>1.0.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>gctoolkit-gclogs</artifactId>
-    <version>1.0.1</version>
     <packaging>pom</packaging>
-
-    <name>GCToolKit Test Assets: GC logs</name>
-    <description>GC logs for testing GCToolKit</description>
-
-
-    <organization>
-        <name>Microsoft Corporation</name>
-        <url>http://microsoft.com</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</connection>
-        <developerConnection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</developerConnection>
-        <url>https://github.com/Microsoft/gctoolkit-testdata</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <id>microsoft</id>
-            <name>Microsoft Corporation</name>
-        </developer>
-    </developers>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/microsoft/gctoolkit-testdata/issues</url>
-    </issueManagement>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
-        </repository>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/gctoolkit-testdata</url>
-        </repository>
-    </distributionManagement>
 
     <build>
         <plugins>

--- a/gctoolkit-shenandoah-logs/pom.xml
+++ b/gctoolkit-shenandoah-logs/pom.xml
@@ -3,67 +3,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.microsoft.gctoolkit</groupId>
+    <parent>
+        <groupId>com.microsoft.gctoolkit</groupId>
+        <artifactId>gctoolkit-testdata</artifactId>
+        <version>1.0.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>gctoolkit-shenandoah-logs</artifactId>
-    <version>1.0.1</version>
     <packaging>pom</packaging>
-
-    <name>GCToolKitTest Assets: Shenandoah logs</name>
-    <description>Shenandoah logs for testing GCToolKit</description>
-
-
-    <organization>
-        <name>Microsoft Corporation</name>
-        <url>http://microsoft.com</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</connection>
-        <developerConnection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</developerConnection>
-        <url>https://github.com/Microsoft/gctoolkit-testdata</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <developers>
-        <developer>
-            <id>microsoft</id>
-            <name>Microsoft Corporation</name>
-        </developer>
-    </developers>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/microsoft/gctoolkit-testdata/issues</url>
-    </issueManagement>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
-        </repository>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/gctoolkit-testdata</url>
-        </repository>
-    </distributionManagement>
 
     <build>
         <plugins>

--- a/gctoolkit-zgc-logs/pom.xml
+++ b/gctoolkit-zgc-logs/pom.xml
@@ -3,67 +3,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.microsoft.gctoolkit</groupId>
+    <parent>
+        <groupId>com.microsoft.gctoolkit</groupId>
+        <artifactId>gctoolkit-testdata</artifactId>
+        <version>1.0.2-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>gctoolkit-zgc-logs</artifactId>
-    <version>1.0.1</version>
     <packaging>pom</packaging>
-
-    <name>GCToolKitTest Assets: ZGC logs</name>
-    <description>ZGC logs for testing GCToolKit</description>
-
-
-    <organization>
-        <name>Microsoft Corporation</name>
-        <url>http://microsoft.com</url>
-    </organization>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
-    <scm>
-        <connection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</connection>
-        <developerConnection>scm:git:git@github.com:Microsoft/gctoolkit-testdata.git</developerConnection>
-        <url>https://github.com/Microsoft/gctoolkit-testdata</url>
-      <tag>HEAD</tag>
-  </scm>
-
-    <developers>
-        <developer>
-            <id>microsoft</id>
-            <name>Microsoft Corporation</name>
-        </developer>
-    </developers>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/microsoft/gctoolkit-testdata/issues</url>
-    </issueManagement>
-
-    <repositories>
-        <repository>
-            <id>central</id>
-            <url>https://repo1.maven.org/maven2</url>
-        </repository>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/*</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/microsoft/gctoolkit-testdata</url>
-        </repository>
-    </distributionManagement>
 
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.microsoft.gctoolkit</groupId>
     <artifactId>gctoolkit-testdata</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GCToolKit Test Data</name>
@@ -65,41 +65,11 @@
         </repository>
     </distributionManagement>
 
-    <!--
     <modules>
         <module>gctoolkit-gclogs</module>
         <module>gctoolkit-gclogs-rolling</module>
+        <module>gctoolkit-shenandoah-logs</module>
         <module>gctoolkit-zgc-logs</module>
     </modules>
-    -->
-
-    <dependencies>
-        <dependency>
-            <groupId>com.microsoft.gctoolkit</groupId>
-            <artifactId>gctoolkit-gclogs</artifactId>
-            <version>1.0.1</version>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.gctoolkit</groupId>
-            <artifactId>gctoolkit-gclogs-rolling</artifactId>
-            <version>1.0.1</version>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.gctoolkit</groupId>
-            <artifactId>gctoolkit-shenandoah-logs</artifactId>
-            <version>1.0.1</version>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.microsoft.gctoolkit</groupId>
-            <artifactId>gctoolkit-zgc-logs</artifactId>
-            <version>1.0.1</version>
-            <type>zip</type>
-        </dependency>
-
-    </dependencies>
-
 
 </project>


### PR DESCRIPTION
One used to have to run mvn install on each pom file. The idea behind having to do this was allowing the zip files to be individually versioned. But this causes all sorts of trouble because it is an atypical way of doing mvn projects. 

This PR makes the sub-directories modules of the parent so that running `mvn install` from the top-level does what one would normally expect. 